### PR TITLE
#184347018 Changing the way of getting token for email verification

### DIFF
--- a/src/documentation/emailVerification.js
+++ b/src/documentation/emailVerification.js
@@ -1,5 +1,5 @@
 const confirmEmail = {
-    tags: ['Eamail verification'],
+    tags: ['Users'],
     description: 'Confirm your email',
     parameters: [{
         name: 'token',

--- a/src/documentation/index.js
+++ b/src/documentation/index.js
@@ -3,6 +3,7 @@ import basicInfo from './basicInfo';
 import userRouteDocs from './user.docs';
 import welcomeRouteDocs from './welcome.docs';
 import profileDocs from './profile.docs.js';
+import confirmEmailRoute from './emailVerification.js';
 
 export default {
   ...basicInfo,
@@ -11,5 +12,6 @@ export default {
     ...authenticationRouteDocs,
     ...userRouteDocs,
     ...profileDocs,
+    ...confirmEmailRoute
   },
 };

--- a/src/middlewares/user.middleware.js
+++ b/src/middlewares/user.middleware.js
@@ -75,6 +75,7 @@ export const checkTokenNotRevoked = async (req, res, next) => {
     where: { token: userToken },
   });
   if (getToken && !getToken.revoked) {
+    req.token = userToken;
     next();
   } else {
     return res
@@ -84,7 +85,7 @@ export const checkTokenNotRevoked = async (req, res, next) => {
 };
 
 export const verifyAndRevokeToken = async (req, res, next) => {
-  const userToken = req.params.token;
+  const userToken = req.token;
   const decoded = JwtUtility.verifyToken(userToken);
   if (decoded) {
     await jwtTokens.update(


### PR DESCRIPTION
#### What does this PR do?
This PR changes the way of getting token

#### Description of Task to be completed?
- Assign token to the request 
- Get token to the request 

#### How should this be manually tested?
- Clone [repo](https://github.com/atlp-rwanda/vikings-ec-bn)
- Checkout branch `refactor/verify-email-184347018`
- Run this command `npm install`
- Run `npm run reset:db`
- Run `npm run dev`
- Open `http://localhost:5000/api-docs` in your browser
- Try to register
- Check your email

#### What are the relevant pivotal tracker stories?
[#184347018](https://www.pivotaltracker.com/story/show/184347040)

#### Screenshots (if appropriate)
![email](https://user-images.githubusercontent.com/90104592/219626057-d44b9038-097d-4a10-8c78-3f0b3bc30739.PNG)

#### Questions:
N/A